### PR TITLE
zammad version is done via repo not package name

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 
-zammad_version: '2.2.2'
+zammad_version: 'stable'
 
 zammad_ssl_dir: '/etc/ssl/zammad'
 zammad_ssl_cert_key_local_path: '/tmp'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,12 +13,12 @@
 
 - name: install zammad yum repo
   yum_repository:
-    baseurl: "https://dl.packager.io/srv/rpm/zammad/zammad/stable/el/7/x86_64"
+    baseurl: "https://dl.packager.io/srv/rpm/zammad/zammad/{{ zammad_version }}/el/7/$basearch"
     gpgcheck: no
-    repo_gpgcheck: no
+    repo_gpgcheck: yes
     gpgkey: "https://dl.packager.io/srv/zammad/zammad/key"
     enabled: yes
-    name: "zammad"
+    name: "zammad-{{ zammad_version }}"
     description: "zammad project repo"
     skip_if_unavailable: yes
   when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "7"
@@ -26,7 +26,7 @@
 - name: install zammad
   yum: pkg={{ item }}
   with_items:
-    - zammad-"{{ zammad_version }}"
+    - zammad
 
 - name: install java openjdk for elasticsearch
   yum: pkg={{ item }}


### PR DESCRIPTION
fixes #2 

For the different versions check https://packager.io/gh/zammad/zammad

Note that I changed the zammad_version from `2.2.2` to `stable`, as I think this makes most sense as default and the specific version 2.2.2 is not selectable anyway. Closest you can get is specify `stable-2.2` in your host_vars/group_vars

Additionally I set `repo_gpgcheck: yes` if you follow the [zammad documentation](https://docs.zammad.org/en/latest/install-centos.html) the downloaded repo has this as well.